### PR TITLE
Fix/large scale refactor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300&display=swap" rel="stylesheet">
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="apple-touch-icon" href="./placeholder-icon.png">
     <title>Tashtego</title>

--- a/src/Components/ActiveBook/ActiveBook.css
+++ b/src/Components/ActiveBook/ActiveBook.css
@@ -5,7 +5,7 @@
 }
 
 .active-cover {
-  width: 56vw;
+  width: 65vw;
 }
 
 .controls {

--- a/src/Components/ActiveBook/ActiveBook.css
+++ b/src/Components/ActiveBook/ActiveBook.css
@@ -29,3 +29,34 @@
 .datectrl {
   font-size: 1em;
 }
+
+
+@media only screen and (min-width: 500px) {
+  .active-cover {
+    width: 45vw;
+  }
+}
+
+@media only screen and (min-width: 700px) {
+  .active-cover {
+    width: 38vw;
+  }
+}
+
+@media only screen and (min-width: 800px) {
+  .active-cover {
+    width: 35vw;
+  }
+}
+
+@media only screen and (min-width: 900px) {
+  .active-cover {
+    width: 30vw;
+  }
+}
+
+@media only screen and (min-width: 1000px) {
+  .active-cover {
+    width: 20vw;
+  }
+}

--- a/src/Components/ActiveBook/ActiveBook.js
+++ b/src/Components/ActiveBook/ActiveBook.js
@@ -1,46 +1,48 @@
 import React, { useEffect } from 'react';
 import moment from 'moment';
 import './ActiveBook.css';
-import { findRemainingDays } from '../../util';
+import { findRemainingDays, formatAuthors } from '../../util';
 import PropTypes from 'prop-types';
 
 export const ActiveBook = ({ book, changeActive, isDateLocked }) => {
-  useEffect(() => {
-    if (book.date <= moment().format('YYYY-MM-DD')) {
-      changeActive(null, null, false)
-    }
-  }, [book, changeActive])
 
   return (
     <div className='active-book'>
-        <img
-          className='active-cover'
-          src={book.cover}
-          alt={book.alt}
-        />
-      <div className='controls'>
-        <button
-          className='controlbtn'
-          onClick={() => changeActive(null, null, true)}
-        >Return to List</button>
-        <button
-          className='controlbtn'
-          onClick={() => changeActive(null, null, false)}
-        >Finished</button>
-      </div>
-      <h1>{book.title}</h1>
-      <h2> by {book.authors[0]}</h2>
-        <h3>
-          You expect to finish {findRemainingDays(book.date)}
-          <input
-            className='datectrl'
-            type='date'
-            min={moment().format('YYYY-MM-DD')}
-            value={book.date}
-            disabled={isDateLocked}
-            onChange={event => changeActive('date', event.target.value, false)}
+      { book.id ?
+        <>
+          <img
+            className='active-cover'
+            src={book.cover}
+            alt={book.alt}
           />
-        </h3>
+        <div className='controls'>
+          <button
+            className='controlbtn'
+            onClick={() => changeActive(null, null, true)}
+          >Return to List</button>
+          <button
+            className='controlbtn'
+            onClick={() => changeActive(null, null, false)}
+          >Finished</button>
+        </div>
+        <h1>{book.title}</h1>
+        <h2> by {formatAuthors(book.authors)}</h2>
+          <h3>
+            You expect to finish {findRemainingDays(book.date)}
+            <input
+              className='datectrl'
+              type='date'
+              min={moment().format('YYYY-MM-DD')}
+              value={book.date}
+              disabled={isDateLocked}
+              onChange={event => changeActive('date', event.target.value, false)}
+            />
+          </h3>
+        </> :
+        <h1 className='landing-message'>
+        It looks like there's nothing here! <br/>
+        Trying searching for some books to add to your list!</h1>
+      }
     </div>
   );
 }

--- a/src/Components/ActiveBook/ActiveBook.js
+++ b/src/Components/ActiveBook/ActiveBook.js
@@ -28,7 +28,7 @@ export const ActiveBook = ({ book, changeActive, isDateLocked }) => {
         <h1>{book.title}</h1>
         <h2> by {formatAuthors(book.authors)}</h2>
           <h3>
-            You expect to finish {findRemainingDays(book.date)}
+            You expect to finish {findRemainingDays(book.date)} 
             <input
               className='datectrl'
               type='date'

--- a/src/Components/App/App.css
+++ b/src/Components/App/App.css
@@ -18,4 +18,5 @@ input {
 
 .landing-message {
   margin-top: 5em;
+  line-height: 1em;
 }

--- a/src/Components/App/App.css
+++ b/src/Components/App/App.css
@@ -15,3 +15,7 @@ input {
   border-color: #44413c;
   color: #44413c
 }
+
+.landing-message {
+  margin-top: 5em;
+}

--- a/src/Components/App/App.css
+++ b/src/Components/App/App.css
@@ -13,10 +13,16 @@ input {
   font-size: 1.2em;
   background-color: #f5f5f5;
   border-color: #44413c;
-  color: #44413c
+  color: #44413c;
+  font-family: "Lato", sans-serif;
 }
 
 .landing-message {
   margin-top: 5em;
   line-height: 1em;
+}
+
+button {
+  font-family: "Lato", sans-serif;
+  font-size: 0.9em;
 }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -20,26 +20,6 @@ export const App = () => {
     }
   );
 
-  useEffect(() => {
-    if (readingList.length && !activeBook.id) {
-      setActiveBook({
-        ...readingList[0],
-        date: moment().add(settings.defaultDays + 1, 'days').format('YYYY-MM-DD')
-      })
-      setReadingList(readingList.splice(1))
-    }
-  }, [readingList, setReadingList,
-    activeBook, setActiveBook,
-    settings.defaultDays])
-
-  const addBook = newBook => {
-    if (!readingList.filter(book => book.id === newBook.id).length
-      && activeBook.id !== newBook.id
-      && !settings.lockList) {
-      setReadingList([ ...readingList, newBook])
-    }
-  }
-
   const changeActive = (modKey, modValue, returnBook) => {
     if (returnBook) {
       setReadingList([ ...readingList, activeBook]);
@@ -55,6 +35,32 @@ export const App = () => {
     }
   }
 
+  useEffect(() => {
+    if (readingList.length && !activeBook.id) {
+      setActiveBook({
+        ...readingList[0],
+        date: moment().add(settings.defaultDays + 1, 'days').format('YYYY-MM-DD')
+      })
+      setReadingList(readingList.splice(1))
+    }
+  }, [readingList, setReadingList,
+    activeBook, setActiveBook,
+    settings.defaultDays])
+
+  useEffect(() => {
+    if (activeBook.date <= moment().format('YYYY-MM-DD')) {
+      changeActive(null, null, false)
+    }
+  }, [activeBook, changeActive])
+
+  const addBook = newBook => {
+    if (!readingList.filter(book => book.id === newBook.id).length
+      && activeBook.id !== newBook.id
+      && !settings.lockList) {
+      setReadingList([ ...readingList, newBook])
+    }
+  }
+
   const checkIfListed = id => {
     if (readingList.filter(book => book.id === id).length ||
       activeBook.id === id) {
@@ -66,16 +72,11 @@ export const App = () => {
   return (
     <div className="App">
       <Route exact path='/' render={() =>
-        (activeBook.id ?
           <ActiveBook
             book={activeBook}
             changeActive={changeActive}
             isDateLocked={settings.lockDate}
-          /> :
-          <h1 className='landing-message'>
-          It looks like there's nothing here! <br/>
-          Trying searching for some books to add to your list!</h1>
-        )
+          />
       }/>
       <Route exact path='/search' render={() =>
         <Search

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import './App.css';
 import { Search } from '../Search/Search';
 import { NavBar } from '../NavBar/NavBar';
@@ -12,6 +12,8 @@ import { useLocalStorage } from '../../util';
 export const App = () => {
   const [readingList, setReadingList] = useLocalStorage('readingList', []);
   const [activeBook, setActiveBook] = useLocalStorage('activeBook', {id: null});
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
   const [settings, setSettings] = useLocalStorage('settings',
     {
     lockList: false,
@@ -82,6 +84,10 @@ export const App = () => {
         <Search
           addBook={addBook}
           checkIfListed={checkIfListed}
+          query={query}
+          setQuery={setQuery}
+          searchResults={searchResults}
+          setSearchResults={setSearchResults}
         />
       }/>
       <Route exact path='/list' render={() =>

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -66,12 +66,16 @@ export const App = () => {
   return (
     <div className="App">
       <Route exact path='/' render={() =>
-        (activeBook.id &&
+        (activeBook.id ?
           <ActiveBook
             book={activeBook}
             changeActive={changeActive}
             isDateLocked={settings.lockDate}
-          />)
+          /> :
+          <h1 className='landing-message'>
+          It looks like there's nothing here! <br/>
+          Trying searching for some books to add to your list!</h1>
+        )
       }/>
       <Route exact path='/search' render={() =>
         <Search

--- a/src/Components/AvailableBooks/AvailableBooks.css
+++ b/src/Components/AvailableBooks/AvailableBooks.css
@@ -36,3 +36,15 @@ h3 {
 .on-list {
   border: 4px solid #80FF80;
 }
+
+@media only screen and (min-width: 750px) {
+  .search-results {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+@media only screen and (min-width: 1000px) {
+  .search-results {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+}

--- a/src/Components/ReadingList/ReadingList.css
+++ b/src/Components/ReadingList/ReadingList.css
@@ -3,7 +3,7 @@
   grid-template-columns: 1fr;
   grid-row-gap: 1em;
   overflow-y: scroll;
-  height: 95vh;
+  height: 84.5vh;
   padding: 1em;
   align-items: start;
 }

--- a/src/Components/ReadingList/ReadingList.js
+++ b/src/Components/ReadingList/ReadingList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { formatAuthors } from '../../util'
 import './ReadingList.css';
 import PropTypes from 'prop-types';
 
@@ -29,7 +30,7 @@ export const ReadingList = ({ readingList, setReadingList, isListLocked }) => {
             />
             <div className='item-info'>
               <h2>{book.title}</h2>
-              <h3> by {book.authors[0]}</h3>
+              <h3> by {formatAuthors(book.authors)}</h3>
               <button
                 className='controlbtn'
                 disabled={isListLocked}

--- a/src/Components/ReadingList/ReadingList.js
+++ b/src/Components/ReadingList/ReadingList.js
@@ -55,6 +55,11 @@ export const ReadingList = ({ readingList, setReadingList, isListLocked }) => {
 
   return (
     <DragDropContext onDragEnd={handleDrop}>
+      {!readingList.length &&
+        <h1 className='landing-message'>
+        It looks like there's nothing here! <br/>
+        Trying searching for some books to add to your list!</h1>
+      }
       <Droppable droppableId="books">
         {provided => (
             <ul

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -39,6 +39,7 @@ export const Search = ({ addBook, checkIfListed }) => {
           name='search'
           value={query}
           type='search'
+          placeholder='search for a book'
           onChange={event => setQuery(event.target.value)}
           onKeyUp={handleSearch}
         />

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -8,9 +8,7 @@ import { usePromiseTracker } from "react-promise-tracker";
 import './Search.css'
 import PropTypes from 'prop-types';
 
-export const Search = ({ addBook, checkIfListed }) => {
-  const [query, setQuery] = useLocalStorage('query', '');
-  const [searchResults, setSearchResults] = useLocalStorage('searchResults', []);
+export const Search = ({ addBook, checkIfListed, query, setQuery, searchResults, setSearchResults }) => {
   const [error, setError] = useState(null);
 
   const handleSearch = async (event, mobileSearch) => {

--- a/src/Components/Settings/Settings.css
+++ b/src/Components/Settings/Settings.css
@@ -1,4 +1,8 @@
 .settings {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
+}
+
+.setting-input {
+  width: 20%;
 }

--- a/src/Components/Settings/Settings.js
+++ b/src/Components/Settings/Settings.js
@@ -15,27 +15,42 @@ export const Settings = ({ settings, setSettings }) => {
 
   return (
     <div className='settings'>
-      <label htmlFor='lockList'>Lock List</label>
-      <input
-        name='lockList'
-        type='checkbox'
-        checked={settings.lockList}
-        onChange={updateSettings}
-      />
+      <h1>
+        <label htmlFor='lockList'>Lock List</label>
+        <input
+          className='setting-input'
+          name='lockList'
+          type='checkbox'
+          checked={settings.lockList}
+          onChange={updateSettings}
+        />
+      </h1>
+      <h2>This option prevents you from adding or removing books
+      from your reading list</h2>
+      <h1>
         <label htmlFor='lockDate'>Lock Date</label>
-      <input
-        name='lockDate'
-        type='checkbox'
-        checked={settings.lockDate}
-        onChange={updateSettings}
-      />
-      <label htmlFor='defaultDays'>Default Days</label>
-      <input
-        name='defaultDays'
-        type='number'
-        value={settings.defaultDays}
-        onChange={updateSettings}
-      />
+        <input
+          className='setting-input'
+          name='lockDate'
+          type='checkbox'
+          checked={settings.lockDate}
+          onChange={updateSettings}
+        />
+      </h1>
+      <h2>This option prevents you from changing
+      the intended completion date of a book</h2>
+      <h1>
+        <label htmlFor='defaultDays'>Default Days </label>
+        <input
+          className='setting-input'
+          name='defaultDays'
+          type='number'
+          value={settings.defaultDays}
+          onChange={updateSettings}
+        />
+      </h1>
+      <h2>This option changes the number of days you expect
+      to read a book by default</h2>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,5 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   height: 100vh;
@@ -16,6 +13,7 @@ code {
 }
 
 html {
+  font-family: "Lato", sans-serif;
   color: #44413c;
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -50,7 +50,7 @@ export const useLocalStorage = (storageKey, defaultState) => {
     }
   });
 
-  const setterFunction = state => {
+  const storageSetterFunction = state => {
     try {
       const stateToStore =
         state instanceof Function ? state(storedState) : state;
@@ -61,5 +61,5 @@ export const useLocalStorage = (storageKey, defaultState) => {
     }
   };
 
-  return [storedState, setterFunction];
+  return [storedState, storageSetterFunction];
 }


### PR DESCRIPTION
This branch fixes several small visual issue that people I had test my app noticed. The biggest change is that it moves the `query` and `searchResults` hooks up to `App`. This improves the UX by keeping search results saved while the app is in use (they don't clear on re-renders of the `Search` component), but clears the search results when the app is closed. Previously the search results were tied to local storage, and some testers described this as "surprising" and "a little weird." 